### PR TITLE
feat: add go-chi router and base template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/dylanxhernandez/proto-gctr
+
+go 1.21.8
+
+require github.com/go-chi/chi/v5 v5.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/main.go
+++ b/main.go
@@ -1,8 +1,20 @@
 package main
 
-import "fmt"
+import (
+	"net/http"
+	"fmt"
+	"html/template"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
 
 func main() {
-    fmt.Println("RUN PROGRAM ----------")
+	fmt.Println("RUN PROGRAM on Port 1313 ----------")
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Get("/", func(w http.ResponseWriter, _ *http.Request) {
+		tmpl, _ := template.New("").ParseFiles("templates/index.html")
+		tmpl.ExecuteTemplate(w, "base", nil)
+	})
+	http.ListenAndServe(":1313", r)
 }
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+{{ define "base" }}
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>Test Page</title>
+	</head>
+	<body>
+		<div class="container">
+			<div class="row">
+				<div class="col">
+					<h1 class="mb-4 mt-4"><strong>Test Page</strong></h1>
+				</div>
+			</div>
+		</div>    
+	</body>
+</html>
+{{ end }}


### PR DESCRIPTION
This change initializes the go modules setup and installs the go-chi router to the application. In addition, a base template is added to the application that will be used for the standard pages.  